### PR TITLE
:bug: Add ntheory module when using primetest. Fixes #2.

### DIFF
--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -2199,7 +2199,7 @@ atoms = {
     "ÆP": attrdict(
         arity = 1,
         ldepth = 0,
-        call = lambda z: int(sympy.primetest.isprime(z))
+        call = lambda z: int(sympy.ntheory.primetest.isprime(z))
     ),
     "Æp": attrdict(
         arity = 1,


### PR DESCRIPTION
Hi!
I took a look this issue when starting to play with jello locally and I think this little change fixes it:
![image](https://github.com/codereport/jellyfish/assets/1158006/235f94b5-6b07-4b4e-a0ea-d86df205242a)

Thanks a lot for all the nice material you put out there, I learn a lot thanks to it!